### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ meetup-group: owasp-tirunelveli-chapter
 
 Welcome to the OWASP Tirunelveli chapter homepage.
 
-The Open Web Application Security Project (OWASP) is a worldwide nonprofit organization that is dedicated to improving the security of software. The main objective of OWASP is to provide insights and tools to help improve application security globally. Every three years, OWASP publishes list of top-ten security flaws obtained from industry data and independent research. These lists contain the most commonly seen, and most commonly exploited vulnerabilities.
+The Open Worldwide Application Security Project (OWASP) is a worldwide nonprofit organization that is dedicated to improving the security of software. The main objective of OWASP is to provide insights and tools to help improve application security globally. Every three years, OWASP publishes list of top-ten security flaws obtained from industry data and independent research. These lists contain the most commonly seen, and most commonly exploited vulnerabilities.
 
 OWASP Tirunelveli was founded in Jan 2022. We organise Meetups, Webinars and Conferences. All these events are open for everyone. We do webinars on topics related to Computer Science and share knowledge mainly on Cyber Security. Join our mission to make Cyber Space a Better Place!
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)